### PR TITLE
Credit info amendments

### DIFF
--- a/_includes/v3/merchant_api.md
+++ b/_includes/v3/merchant_api.md
@@ -29,7 +29,7 @@ Field | Type | Notes
 `code` | int | For error results the code field will be always a negative integer. Codes for errors will be as described below.
 `response` | object | Response object will contain a message field describing the error.
 
-##### Standard API Errors
+##### Standard API Errors
 
 Code | Message | Meaning
 --- | --- | ---

--- a/_includes/v4/installations.md
+++ b/_includes/v4/installations.md
@@ -143,8 +143,7 @@ Name | Required | Type | Description
                         "term": 9,
                         "total_cost": 52900
                     },
-                    "total_cost": 74598,
-                    "total_repayment": 74598
+                    "total_cost": 74598
                 }
             },
             {
@@ -208,8 +207,7 @@ Name | Required | Type | Description
                         "term": 12,
                         "total_cost": 52900
                     },
-                    "total_cost": 79295,
-                    "total_repayment": 79295
+                    "total_cost": 79295
                 }
             }
         ]
@@ -269,8 +267,7 @@ Name | Required | Type | Description
                     "payment_start_iso": "2015-07-01",
                     "payment_start_nice": "Wednesday 1st July 2015",
                     "payments": 12,
-                    "total_cost": 51370,
-                    "total_repayment": 51370
+                    "total_cost": 51370
                 }
             }
         ]

--- a/_includes/v4/objects.md
+++ b/_includes/v4/objects.md
@@ -140,7 +140,7 @@ Name | Required | Type | Description | Displayed As
 
 The promotional object is used when there is a promotional offer for
 a particular product, e.g. Buy Now Pay Later, as you can settle
-early and pay less fees.
+early and pay less interest.
 
 #### Example
 

--- a/_includes/v4/objects.md
+++ b/_includes/v4/objects.md
@@ -123,3 +123,38 @@ Name | Required | Type | Description
     "location": "Walmington-on-Sea Store"
 }
 ```
+### Promotional
+
+#### Parameters
+
+Name | Required | Type | Description | Displayed As
+--- | --- | --- | --- | ---
+`$.customer_settlement_fee` | Yes | int *or* null | The amount of settlement fee in pence or `null` for products where the settlement fee is not applicable. | Settlement Fee
+`$.date_end_iso` | Yes | date | The ISO 8601 date when the promotional period ends. | N/A
+`$.date_end_nice` | Yes | string | The date when the promotional period ends in plain English. | Promotional End Date
+`$.deposit_amount` | Yes | int | The amount of deposit in pence used for the credit information. | Deposit
+`$.loan_amount` | Yes | int | The loan amount in pence, being the `$.order_amount` − `$.deposit_amount`. | Loan Amount
+`$.order_amount` | Yes | int | The order amount in pence. | Price
+`$.term` | Yes | int | The number of months before the promotional period ends. | N/A
+`$.total_cost` | Yes | int | The total cost in pence, being `$.order_amount` + `$.customer_settlement_fee`. | Total Repayable
+
+The promotional object is used when there is a promotional offer for
+a particular product, e.g. Buy Now Pay Later, as you can settle
+early and pay less fees.
+
+#### Example
+
+```json
+{
+    "promotional": {
+        "customer_settlement_fee": 2900,
+        "date_end_iso": "2015-09-17",
+        "date_end_nice": "Thursday 17th September 2015",
+        "deposit_amount": 5000,
+        "loan_amount": 45000,
+        "order_amount": 50000,
+        "term": 6,
+        "total_cost": 52900
+    }
+}
+```

--- a/_includes/v4/products.md
+++ b/_includes/v4/products.md
@@ -290,37 +290,28 @@ Name | Required | Type | Description
 
 #### Response
 
-Name | Required | Type | Description
---- | --- | --- | ---
-`$.amount_service` | Yes | int | The service fee in pence.
-`$.apr` | Yes | float | The APR for the credit information returned.
-`$.customer_settlement_fee` | Yes | int *or* null | The amount of settlement fee in pence or `null` for products where the settlement fee is not applicable.
-`$.deposit_amount` | Yes | int | The amount of deposit in pence used for the credit information.
-`$.deposit_range.minimum_amount` | Yes | int | The minimum deposit for the `$.loan_amount` and product in pence.
-`$.deposit_range.maximum_amount` | Yes | int | The maximum deposit for the `$.loan_amount` and product in pence.
-`$.holiday` | Yes | int | Holiday period in months.
-`$.initial_payment_upfront` | Yes | bool | A boolean denoting if an initial payment is required at the point of the customer signing up for finance.
-`$.loan_amount` | Yes | int | The loan amount in pence, being the `$.order_amount` − `$.deposit_amount`.
-`$.loan_cost` | Yes | int | The total cost of the loan in pence including interest and `$.amount_service`.
-`$.loan_repayment` | Yes | int | The total repayment due on the loan in pence, being the `$.loan_amount` + `$.loan_cost`.
-`$.offered_rate` | Yes | float | The per annum interest rate offered.
-`$.order_amount` | Yes | int | The order amount in pence.
-`$.payment_final` | Yes | int | The final payment amount in pence.
-`$.payment_regular` | Yes | int | The regular payment amount in pence.
-`$.payment_start_iso` | Yes | date | The ISO 8601 date of the first payment.
-`$.payment_start_nice` | Yes | string | The date of the first payment in plain English.
-`$.payments` | Yes | int | The number of payments to be made.
-`$.promotional` | No | object | Present when a promotional option is available, e.g. for Buy Now Pay Later.
-`$.promotional.customer_settlement_fee` | Yes | int *or* null | The amount of settlement fee in pence or `null` for products where the settlement fee is not applicable.
-`$.promotional.date_end_iso` | Yes | int | The ISO 8601 date when the promotional period ends.
-`$.promotional.date_end_nice` | Yes | int | The date when the promotional period ends in plain English.
-`$.promotional.deposit_amount` | Yes | int | The amount of deposit in pence used for the credit information.
-`$.promotional.loan_amount` | Yes | int | The loan amount in pence, being the `$.order_amount` − `$.deposit_amount`.
-`$.promotional.order_amount` | Yes | int | The order amount in pence.
-`$.promotional.term` | Yes | int | The number of months before the promotional period ends.
-`$.promotional.total_cost` | Yes | int | The total cost in pence, being `$.order_amount` + `$.customer_settlement_fee`.
-`$.total_cost` | Yes | int | The total cost in pence, being `$.order_amount` + `$.loan_cost`.
-
+Name | Required | Type | Description | Displayed As
+--- | --- | --- | --- | ---
+`$.amount_service` | Yes | int | The service fee in pence. | Service Fee
+`$.apr` | Yes | float | The APR for the credit information returned. | APR
+`$.customer_settlement_fee` | Yes | int *or* null | The amount of settlement fee in pence or `null` for products where the settlement fee is not applicable. | Settlement Fee
+`$.deposit_amount` | Yes | int | The amount of deposit in pence used for the credit information. | Deposit
+`$.deposit_range.minimum_amount` | Yes | int | The minimum deposit for the `$.loan_amount` and product in pence. | Minimum Deposit
+`$.deposit_range.maximum_amount` | Yes | int | The maximum deposit for the `$.loan_amount` and product in pence. | Maximum Deposit
+`$.holiday` | Yes | int | Holiday period in months. | Payment Holiday(s)
+`$.initial_payment_upfront` | Yes | bool | A boolean denoting if an initial payment is required at the point of the customer signing up for finance. | N/A
+`$.loan_amount` | Yes | int | The loan amount in pence, being the `$.order_amount` − `$.deposit_amount`. | Loan Amount
+`$.loan_cost` | Yes | int | The total cost of the loan in pence including interest and `$.amount_service`. | Total Cost of Credit
+`$.loan_repayment` | Yes | int | The total repayment due on the loan in pence, being the `$.loan_amount` + `$.loan_cost`. | Total
+`$.offered_rate` | Yes | float | The per annum interest rate offered. | Interest Rate
+`$.order_amount` | Yes | int | The order amount in pence. | Price
+`$.payment_final` | Yes | int | The final payment amount in pence. | Final Monthly Payment
+`$.payment_regular` | Yes | int | The regular payment amount in pence. | Monthly Payment
+`$.payment_start_iso` | Yes | date | The ISO 8601 date of the first payment. | N/A
+`$.payment_start_nice` | Yes | string | The date of the first payment in plain English. | First Payment Date
+`$.payments` | Yes | int | The number of payments to be made. | Number of Payments
+`$.promotional` | No | [promotional](#promotional) | Present when a promotional option is available, e.g. Option 1 for Buy Now Pay Later. | None
+`$.total_cost` | Yes | int | The total cost in pence, being `$.order_amount` + `$.loan_cost`. | Total Repayable
 ```json
 {
     "amount_service": 0,

--- a/_includes/v4/products.md
+++ b/_includes/v4/products.md
@@ -319,8 +319,7 @@ Name | Required | Type | Description
 `$.promotional.order_amount` | Yes | int | The order amount in pence.
 `$.promotional.term` | Yes | int | The number of months before the promotional period ends.
 `$.promotional.total_cost` | Yes | int | The total cost in pence, being `$.order_amount` + `$.customer_settlement_fee`.
-`$.total_cost` | Yes | int | The total cost in pence, being `$.order_amount` + `$.loan_cost` + `$.amount_service`.
-`$.total_repayment` | Yes | int | The total repayment in pence, being the `$.order_amount` + `$.loan_cost`.
+`$.total_cost` | Yes | int | The total cost in pence, being `$.order_amount` + `$.loan_cost`.
 
 ```json
 {
@@ -354,7 +353,6 @@ Name | Required | Type | Description
         "term": 6,
         "total_cost": 52900
     },
-    "total_cost": 70203,
-    "total_repayment": 70203
+    "total_cost": 70203
 }
 ```

--- a/_includes/v4/toc.html
+++ b/_includes/v4/toc.html
@@ -21,6 +21,7 @@
             <li><a href="#order">Order</a></li>
             <li><a href="#product-range">Product Range</a></li>
             <li><a href="#fulfilment">Fulfilment</a></li>
+            <li><a href="#promotional">Promotional</a></li>
         </ul>
     </ul>
 </ul>


### PR DESCRIPTION
## Features
- Removed `Total Repayment`
- Total cost no longer includes `amount service`
- Added `Promotional` object
- Removed `Promotional` fields from credit info call, replaced with the object
- Added `displayed as` field for credit information to relate to what the fields are called in the front end

## Bug Fixes
- Fixed `/v3/merchant_api.md` as there was an invalid character